### PR TITLE
Revert "Use Go 1.7 in Drone and golang-version-check."

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: clever/drone-go:1.7
+image: clever/drone-go:1.6
 notify:
   email:
     recipients:


### PR DESCRIPTION
Reverts Clever/godoc-docker#3

This failed to launch in prod.
