### PR TITLE
Added cpu

### DIFF
--- a/launch/godoc-docker.yml
+++ b/launch/godoc-docker.yml
@@ -14,3 +14,5 @@ elbs:
   production:
     - godoc
 team: eng-infra
+resources:
+  cpu: 0.5


### PR DESCRIPTION
Catapult is changing its default CPU value to 0.  Setting a literal value to ensure app continue allocating expected resources.